### PR TITLE
Request WebSocket capabilities for clipboard RPC

### DIFF
--- a/packages/clipboard-worker/src/parts/CreateFileSystemProcessRpcNode/CreateFileSystemProcessRpcNode.ts
+++ b/packages/clipboard-worker/src/parts/CreateFileSystemProcessRpcNode/CreateFileSystemProcessRpcNode.ts
@@ -1,14 +1,29 @@
 import { type Rpc, WebSocketRpcParent } from '@lvce-editor/rpc'
+import { RendererWorker } from '@lvce-editor/rpc-registry'
 import { VError } from '@lvce-editor/verror'
 import * as GetWebSocketUrl from '../GetWebSocketUrl/GetWebSocketUrl.ts'
 import * as Location from '../Location/Location.ts'
 
-export const createClipBoardProcessRpcNode = async (): Promise<Rpc> => {
+const createWebSocket = async (): Promise<WebSocket> => {
   try {
+    const { protocols, url } = (await RendererWorker.invoke('WebSocketCapability.create', 'clipboard-process')) as {
+      readonly protocols: string[]
+      readonly url: string
+    }
+    return new WebSocket(url, protocols)
+  } catch (error) {
+    if (!(error instanceof Error && error.message.includes('WebSocketCapability.create') && /command not found|not found/i.test(error.message))) {
+      throw error
+    }
     const host = Location.getHost()
     const protocol = Location.getProtocol()
-    const wsUrl = GetWebSocketUrl.getWebSocketUrl('clipboard-process', host, protocol)
-    const webSocket = new WebSocket(wsUrl)
+    return new WebSocket(GetWebSocketUrl.getWebSocketUrl('clipboard-process', host, protocol))
+  }
+}
+
+export const createClipBoardProcessRpcNode = async (): Promise<Rpc> => {
+  try {
+    const webSocket = await createWebSocket()
     const rpc = await WebSocketRpcParent.create({
       commandMap: {},
       webSocket,


### PR DESCRIPTION
Requests a renderer-issued one-use capability before connecting to the clipboard process, with a command-missing fallback for older editors.