### PR TITLE
fix: support pre-capability renderers

### DIFF
--- a/packages/clipboard-worker/src/parts/CreateFileSystemProcessRpcNode/CreateFileSystemProcessRpcNode.ts
+++ b/packages/clipboard-worker/src/parts/CreateFileSystemProcessRpcNode/CreateFileSystemProcessRpcNode.ts
@@ -12,7 +12,13 @@ const createWebSocket = async (): Promise<WebSocket> => {
     }
     return new WebSocket(url, protocols)
   } catch (error) {
-    if (!(error instanceof Error && error.message.includes('WebSocketCapability.create') && /command not found|not found/i.test(error.message))) {
+    if (
+      !(
+        error instanceof Error &&
+        (error.message.includes('WebSocketCapability.create') || error.message.includes('module WebSocketCapability not found')) &&
+        /command not found|not found/i.test(error.message)
+      )
+    ) {
       throw error
     }
     const host = Location.getHost()


### PR DESCRIPTION
## Summary

Recognize the exact missing WebSocketCapability module error returned by older renderer builds and use the existing legacy transport during the dependency-first rollout.

Authorization and connection errors still do not downgrade to the legacy transport.

Follow-up to the capability-gated RPC producer migration.