### PR TITLE
fix: use clipboard worker rpc id

### DIFF
--- a/packages/clipboard-worker/src/parts/SendMessagePortToRendererProcess/SendMessagePortToRendererProcess.ts
+++ b/packages/clipboard-worker/src/parts/SendMessagePortToRendererProcess/SendMessagePortToRendererProcess.ts
@@ -4,5 +4,5 @@ import * as RendererWorker from '../RendererWorker/RendererWorker.ts'
 export const sendMessagePortToRendererProcess = async (port: MessagePort): Promise<void> => {
   const command = 'HandleMessagePort.handleMessagePort'
   // @ts-ignore
-  await RendererWorker.invokeAndTransfer('SendMessagePortToExtensionHostWorker.sendMessagePortToRendererProcess', port, command, RpcId.DebugWorker)
+  await RendererWorker.invokeAndTransfer('SendMessagePortToExtensionHostWorker.sendMessagePortToRendererProcess', port, command, RpcId.ClipBoardWorker)
 }

--- a/packages/clipboard-worker/test/SendMessagePortToRendererProcess.test.ts
+++ b/packages/clipboard-worker/test/SendMessagePortToRendererProcess.test.ts
@@ -10,7 +10,7 @@ jest.unstable_mockModule('../src/parts/RendererWorker/RendererWorker.ts', () => 
 
 jest.unstable_mockModule('@lvce-editor/rpc-registry', () => ({
   RpcId: {
-    DebugWorker: 55,
+    ClipBoardWorker: 3400,
   },
 }))
 
@@ -30,6 +30,6 @@ test('sendMessagePortToRendererProcess should invoke and transfer port', async (
     'SendMessagePortToExtensionHostWorker.sendMessagePortToRendererProcess',
     mockPort,
     'HandleMessagePort.handleMessagePort',
-    55,
+    3400,
   )
 })


### PR DESCRIPTION
The clipboard worker registered its direct renderer-process message port under `RpcId.DebugWorker`. Starting it therefore replaced and disposed any existing Debug Worker direct RPC, including the test worker connection used by the Explorer E2E page object.

Use `RpcId.ClipBoardWorker` so each direct renderer-process RPC keeps its own registry entry.

Tests:
- `npm test`
- `npm run type-check`
- `npm run lint`
- reproduced the Explorer context-menu copy-path benchmark hang and verified it passes with this RPC id