### PR TITLE
fix: use clipboard renderer process port sender

### DIFF
--- a/packages/clipboard-worker/src/parts/CreateRendererProcessRpc/CreateRendererProcessRpc.ts
+++ b/packages/clipboard-worker/src/parts/CreateRendererProcessRpc/CreateRendererProcessRpc.ts
@@ -1,12 +1,12 @@
 import { type Rpc, TransferMessagePortRpcParent } from '@lvce-editor/rpc'
 import { VError } from '@lvce-editor/verror'
-import * as RendererWorker from '../RendererWorker/RendererWorker.ts'
+import * as SendMessagePortToRendererProcess from '../SendMessagePortToRendererProcess/SendMessagePortToRendererProcess.ts'
 
 export const createRendererProcessRpc = async (): Promise<Rpc> => {
   try {
     const rpc = await TransferMessagePortRpcParent.create({
       commandMap: {},
-      send: RendererWorker.sendMessagePortToRendererProcess,
+      send: SendMessagePortToRendererProcess.sendMessagePortToRendererProcess,
     })
     return rpc
   } catch (error) {

--- a/packages/clipboard-worker/test/CreateRendererProcessRpc.test.ts
+++ b/packages/clipboard-worker/test/CreateRendererProcessRpc.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const mockCreate = jest.fn() as jest.MockedFunction<any>
+const mockSendMessagePortToRendererProcess = jest.fn() as jest.MockedFunction<any>
+
+jest.unstable_mockModule('@lvce-editor/rpc', () => ({
+  TransferMessagePortRpcParent: {
+    create: mockCreate,
+  },
+}))
+
+jest.unstable_mockModule('../src/parts/SendMessagePortToRendererProcess/SendMessagePortToRendererProcess.ts', () => ({
+  sendMessagePortToRendererProcess: mockSendMessagePortToRendererProcess,
+}))
+
+const CreateRendererProcessRpc = await import('../src/parts/CreateRendererProcessRpc/CreateRendererProcessRpc.ts')
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test('uses the clipboard worker renderer process port sender', async () => {
+  const mockRpc = {}
+  mockCreate.mockResolvedValue(mockRpc)
+
+  const rpc = await CreateRendererProcessRpc.createRendererProcessRpc()
+
+  expect(rpc).toBe(mockRpc)
+  expect(mockCreate).toHaveBeenCalledWith({
+    commandMap: {},
+    send: mockSendMessagePortToRendererProcess,
+  })
+})


### PR DESCRIPTION
The previous RPC-id correction updated the dedicated clipboard port sender, but `CreateRendererProcessRpc` still called the generic rpc-registry helper, so that sender was tree-shaken out of the published bundle.

Wire renderer-process RPC creation to the dedicated clipboard sender. The built bundle now registers `ClipBoardWorker` (`3400`) instead of `DebugWorker` (`55`).

Tests:
- `npm test` (73 passed)
- `npm run type-check`
- `npm run lint`
- `npm run build`, followed by inspection of the generated worker bundle